### PR TITLE
Additional locale setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ MAINTAINER Dave Coleman dave@dav.ee
 RUN apt-get update && apt-get install -y locales
 RUN locale-gen en_US en_US.UTF-8
 RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
 
 # lsb-release is required for the keys
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ubuntu:16.04
 MAINTAINER Dave Coleman dave@dav.ee
 
 # setup environment
+RUN apt-get update && apt-get install -y locales
 RUN locale-gen en_US en_US.UTF-8
 RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 


### PR DESCRIPTION
the ubuntu docker images don't ship with locales pre-installed as of recently. this updates your dockerfile to do similar setup as [what we use on the ROS 1 buildfarm](https://github.com/ros-infrastructure/ros_buildfarm/blob/3fbf176d595b96d2af96f032c251376baf495baa/ros_buildfarm/templates/snippet/setup_locale.Dockerfile.em).

As part of that, it sets the default encoding of strings in python to be utf-8 which should address https://github.com/ros2/ros2/issues/338